### PR TITLE
Change environment to enable GPU

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
 - conda-forge
 - defaults
 dependencies:
-- python>=3.7
+- python>=3.7<3.12
 - pandas>=0.23.4
 - xlrd>=1.1.0
 - numpy>=1.15.2
@@ -17,6 +17,8 @@ dependencies:
 - openpyxl>=2.5.1
 - requests>=2.21.0
 - lxml>=4.3.1
+- cuda-runtime=12.5.1.*
+- pytorch=2.3.1
 - r-base>=3.6
 - r-dplyr>=0.7.6
 - r-tidyr>=0.8.0

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
 - conda-forge
 - defaults
 dependencies:
-- python>=3.7<3.12
+- python>=3.7,<3.12
 - pandas>=0.23.4
 - xlrd>=1.1.0
 - numpy>=1.15.2


### PR DESCRIPTION
PyTorch wasn't seeing the GPU. I have it working on my end, but I'm hoping building an environment from this yml will allow you to implement it as well.

To update an environment from file:

`conda env update --file environment.yml --prune`

Notes:

First remove old drivers: https://forums.developer.nvidia.com/t/nvidia-smi-has-failed-because-it-couldnt-communicate-with-the-nvidia-driver-make-sure-that-the-latest-nvidia-driver-is-installed-and-running/197141

This is the approach I used to get the GPU integration working: https://developer.nvidia.com/cuda-downloads?target_os=Linux&target_arch=x86_64&Distribution=Ubuntu&target_version=22.04&target_type=deb_network

And then https://www.tensorflow.org/install/pip